### PR TITLE
Drop nysed_activeinstitutions_tmp before each run

### DIFF
--- a/facdb_build/sql/nysed_activeinstitutions.sql
+++ b/facdb_build/sql/nysed_activeinstitutions.sql
@@ -6,6 +6,7 @@ DROP COLUMN IF EXISTS ogc_fid;
 ALTER TABLE nysed_nonpublicenrollment 
 DROP COLUMN IF EXISTS ogc_fid;
 
+DROP TABLE IF EXISTS nysed_activeinstitutions_tmp;
 CREATE TABLE nysed_activeinstitutions_tmp as (SELECT
 
 		nysed_activeinstitutions.*,


### PR DESCRIPTION
Related to the following [run](https://github.com/NYCPlanning/db-facilities/runs/1493312805?check_suite_focus=true) error:

```
psql:sql/nysed_activeinstitutions.sql:26: ERROR:  relation "nysed_activeinstitutions_tmp" already exists
psql:sql/nysed_activeinstitutions.sql:28: ERROR:  current transaction is aborted, commands ignored until end of transaction block
psql:sql/nysed_activeinstitutions.sql:29: ERROR:  current transaction is aborted, commands ignored until end of transaction block
psql:sql/nysed_activeinstitutions.sql:30: ERROR:  current transaction is aborted, commands ignored until end of transaction block
psql:sql/nysed_activeinstitutions.sql:48: ERROR:  current transaction is aborted, commands ignored until end of transaction block
psql:sql/nysed_activeinstitutions.sql:204: ERROR:  current transaction is aborted, commands ignored until end of transaction block
psql:sql/nysed_activeinstitutions.sql:227: ERROR:  current transaction is aborted, commands ignored until end of transaction block
psql:sql/nysed_activeinstitutions.sql:229: ERROR:  current transaction is aborted, commands ignored until end of transaction block
psql:sql/nysed_activeinstitutions.sql:230: ERROR:  current transaction is aborted, commands ignored until end of transaction block
psql:sql/nysed_activeinstitutions.sql:231: ERROR:  current transaction is aborted, commands ignored until end of transaction block
ROLLBACK
```

This should also resolve:

```
psql:sql/load_and_combine.sql:40: ERROR:  column "hash" does not exist
LINE 43:         SELECT hash, 
                        ^
```