### PR TITLE
Change table_name to dcp_facilities

### DIFF
--- a/facdb_build/sql/qc_views.sql
+++ b/facdb_build/sql/qc_views.sql
@@ -7,7 +7,7 @@ DROP VIEW IF EXISTS qc_proptype;
 DROP VIEW IF EXISTS qc_mapped;
 DROP VIEW IF EXISTS qc_diff;
 
-ALTER TABLE table_name 
+ALTER TABLE dcp_facilities 
 DROP COLUMN geom;
 
 ALTER TABLE dcp_facilities


### PR DESCRIPTION
Related to two errors:

```
psql:sql/qc_views.sql:11: ERROR:  relation "table_name" does not exist
psql:sql/qc_views.sql:14: ERROR:  column "geom" of relation "dcp_facilities" already exists
```