### PR TITLE
WIP: Group 6 python extractors

### DIFF
--- a/facdb/datasets.yml
+++ b/facdb/datasets.yml
@@ -13,3 +13,11 @@ datasets:
     version: 20210409
   - name: dcp_pops
     version: 20210409
+  - name: nycha_communitycenters
+    version: 20191118
+  - name: nycha_policeservice
+    version: 20160915
+  - name: nycourts_courts
+    version: 20210413
+  - name: nysdec_lands
+    version: 20210415

--- a/facdb/pipelines.py
+++ b/facdb/pipelines.py
@@ -4,18 +4,6 @@ import pandas as pd
 
 from . import Export, Function1B, FunctionBL, FunctionBN, ParseAddress, Prepare
 
-COUNTY_BORO = {
-    "New York": "Manhattan",
-    "Bronx": "Bronx",
-    "Kings": "Brooklyn",
-    "Queens": "Queens",
-    "Richmond": "Staten Island",
-    "NEW YORK": "Manhattan",
-    "BRONX": "Bronx",
-    "KINGS": "Brooklyn",
-    "QUEENS": "Queens",
-    "RICHMOND": "Staten Island",
-}
 
 
 @Export

--- a/facdb/pipelines.py
+++ b/facdb/pipelines.py
@@ -4,6 +4,19 @@ import pandas as pd
 
 from . import Export, Function1B, FunctionBL, FunctionBN, ParseAddress, Prepare
 
+COUNTY_BORO = {
+    "New York": "Manhattan",
+    "Bronx": "Bronx",
+    "Kings": "Brooklyn",
+    "Queens": "Queens",
+    "Richmond": "Staten Island",
+    "NEW YORK": "Manhattan",
+    "BRONX": "Bronx",
+    "KINGS": "Brooklyn",
+    "QUEENS": "Queens",
+    "RICHMOND": "Staten Island",
+}
+
 
 @Export
 @Function1B(
@@ -240,18 +253,40 @@ def nycdoc_corrections(df: pd.DataFrame = None):
 
 
 @Export
+@Function1B(
+    street_name_field="parsed_sname",
+    house_number_field="parsed_hnum",
+    borough_field="borough",
+)
+@ParseAddress(raw_address_field="address")
+@FunctionBL(bbl_field="bbl")
+@FunctionBN(bin_field="bin")
 @Prepare
 def nycha_communitycenters(df: pd.DataFrame = None):
     return df
 
 
 @Export
+@Function1B(
+    street_name_field="parsed_sname",
+    house_number_field="parsed_hnum",
+    borough_field="borough",
+    zipcode_field="zipcode",
+)
+@ParseAddress(raw_address_field="address")
 @Prepare
 def nycha_policeservice(df: pd.DataFrame = None):
     return df
 
 
 @Export
+@Function1B(
+    street_name_field="parsed_sname",
+    house_number_field="parsed_hnum",
+    borough_field="borough",
+    zipcode_field="zipcode",
+)
+@ParseAddress(raw_address_field="address")
 @Prepare
 def nycourts_courts(df: pd.DataFrame = None):
     return df
@@ -260,6 +295,7 @@ def nycourts_courts(df: pd.DataFrame = None):
 @Export
 @Prepare
 def nysdec_lands(df: pd.DataFrame = None):
+    df = df[df.county.isin(["NEW YORK", "KINGS", "BRONX", "QUEENS", "RICHMOND"])]
     return df
 
 


### PR DESCRIPTION
Known issue: For nysdec_lands, filtering by county causes the `prepare` decorator to fail to add the `source` field. Why?