### PR TITLE
Use 1B for bin

### DIFF
--- a/facdb/pipelines.py
+++ b/facdb/pipelines.py
@@ -84,8 +84,13 @@ def dcla_culturalinstitutions(df: pd.DataFrame = None):
 
 
 @Export
+@FunctionBL(bbl_field="bbl")
+@Function1B(
+    street_name_field="sname", house_number_field="hnum", borough_field="borough"
+)
 @Prepare
 def dcp_colp(df: pd.DataFrame = None):
+    df["bbl"] = df.bbl.str.split(pat=".").str[0]
     return df
 
 

--- a/facdb/sql/dcp_colp.sql
+++ b/facdb/sql/dcp_colp.sql
@@ -27,7 +27,7 @@ WITH _dcp_colp_tmp AS(
         NULL as zipcode,
         NULL as boro,
         borough as borocode,
-        NULL as bin,
+        nullif(geo_1b->'result'->>'geo_bin','') as bin,
         left(bbl, 10) as bbl,
         (
             CASE


### PR DESCRIPTION
#474

This takes BIN from 1B call using source addresses. We might not want to do this if addresses aren't reliable enough. Taking geo_address from BL yielded all NULLs.

The rest of the 1b and bl results aren't kept in _dcp_colp so the remaining spatial logic won't get applied.