### PR TITLE
Fix dsny fooddrops pipeline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,6 +9,7 @@ repos:
     rev: 19.3b0
     hooks:
     -   id: black
+        additional_dependencies: ['click==8.0.4']
 -   repo: https://github.com/PyCQA/isort
     rev: 5.7.0
     hooks:

--- a/facdb/datasets.yml
+++ b/facdb/datasets.yml
@@ -5,7 +5,7 @@ datasets:
       - nypl_libraries.sql
 
   - name: bpl_libraries
-    version: 20210511
+    version: 20220415
     scripts:
       - bpl_libraries.sql
 

--- a/facdb/datasets.yml
+++ b/facdb/datasets.yml
@@ -15,7 +15,6 @@ datasets:
       - dcp_colp.sql
 
   - name: dca_operatingbusinesses
-    version: 20210402
     scripts:
       - dca_operatingbusinesses.sql
 

--- a/facdb/pipelines.py
+++ b/facdb/pipelines.py
@@ -359,6 +359,9 @@ def dsny_leafdrop(df: pd.DataFrame = None):
 @ParseAddress(raw_address_field="location")
 @Prepare
 def dsny_fooddrop(df: pd.DataFrame = None):
+    df["zip_code"] = df["location"].apply(
+        lambda x: x[:-5] if x[:-5].isnumeric() else None
+    )
     return df
 
 

--- a/facdb/sql/dsny_fooddrop.sql
+++ b/facdb/sql/dsny_fooddrop.sql
@@ -13,7 +13,7 @@ SELECT uid,
     NULL as bbl,
     'Compost' as factype,
     'DSNY Drop-off Facility' as facsubgrp,
-    serviced_by as opname,
+    hosted_by as opname,
     NULL as opabbrev,
     'NYCDSNY' as overabbrev,
     NULL as capacity,
@@ -21,8 +21,6 @@ SELECT uid,
     wkt::geometry as wkb_geometry,
     geo_1b,
     NULL as geo_bl,
-    NULL as geo_bn
-INTO _dsny_fooddrop
+    NULL as geo_bn INTO _dsny_fooddrop
 FROM dsny_fooddrop;
-
 CALL append_to_facdb_base('_dsny_fooddrop');

--- a/facdb/utility/prepare.py
+++ b/facdb/utility/prepare.py
@@ -19,11 +19,12 @@ def get_dataset_version(name: str) -> str:
     datasets = read_datasets_yml()
     dataset = next(filter(lambda x: x["name"] == name, datasets), None)
     assert dataset, f"{name} is not included as a dataset in datasets.yml"
-    return str(dataset["version"])
+    return str(dataset.get("version", "latest"))
 
 
 def read_csv(name: str) -> pd.DataFrame:
     version = get_dataset_version(name)
+    print(f"version is {version}")
     return pd.read_csv(
         f"{BASE_URL}/{name}/{version}/{name}.csv", dtype=str, index_col=False
     )
@@ -37,6 +38,7 @@ def Prepare(func) -> callable:
         pkl_path = BASE_PATH / f"{name}.pkl"
         if not os.path.isfile(pkl_path):
             # pull from data library
+            print("pulling from data library")
             # fmt:off
             df = read_csv(name)\
                 .pipe(hash_each_row)\
@@ -45,6 +47,7 @@ def Prepare(func) -> callable:
             # fmt:on
         else:
             # read from cache
+            print("reading from cached data")
             df = pd.read_pickle(pkl_path)
 
         # Apply custom wrangler


### PR DESCRIPTION
 There were two changes that effected our pipeline. The first is that the zip code column was removed and zip moved to location. The second change is that the serviced_by column was removed and a hosted_by column was added.

The zip is parsed from the location column with this code

    df["zip_code"] = df["location"].apply(
        lambda x: x[:-5] if x[:-5].isnumeric() else None
    )
The serviced_by column was used to populate the opname column in the cleaned version of the table. This was changed so that opname is populated by the hosted_by column