### PR TITLE
Don't build on push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,13 +1,6 @@
 name: Build
 
 on:
-  push:
-    paths-ignore:
-      - "*.md"
-      - ".pre-commit-config.yml"
-      - ".gitignore"
-      - "docs/*"
-      - "dashboard/*"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Taking away this option after an accidental build led to an erroneous qaqc page. Think building on push is too easy to do accidentally. 

Curious what other engineers think but ultimately waiting for Amanda to ok before merging. 