### PR TITLE
update dot verison to latest with most recent data via email

### DIFF
--- a/facdb/datasets.yml
+++ b/facdb/datasets.yml
@@ -81,27 +81,22 @@ datasets:
       - nysdec_lands.sql
 
   - name: dot_bridgehouses
-    version: 20210413
     scripts:
       - dot_bridgehouses.sql
 
   - name: dot_ferryterminals
-    version: 20210413
     scripts:
       - dot_ferryterminals.sql
 
   - name: dot_mannedfacilities
-    version: 20210413
     scripts:
       - dot_mannedfacilities.sql
 
   - name: dot_pedplazas
-    version: 20210413
     scripts:
       - dot_pedplazas.sql
 
   - name: dot_publicparking
-    version: 20210413
     scripts:
       - dot_publicparking.sql
 


### PR DESCRIPTION
Very simple - remove version from `datasets.yml` and default to latest for all DOT datasets we receive via email, checked all datasets to ensure they work with current sql/python process and all checked out