### PR TITLE
Update DOE lcgms to latest

### DIFF
--- a/facdb/datasets.yml
+++ b/facdb/datasets.yml
@@ -186,7 +186,6 @@ datasets:
   - name: sca_enrollment_capacity
 
   - name: doe_lcgms
-    version: 20210216
     scripts:
       - doe_lcgms.sql
 


### PR DESCRIPTION
address #560 

Switching the sql to use the latest updated doe lcgms version. Both the sql and python part were checked and also checked the 2021 new data were successfully loaded into the table after the two steps. 