### PR TITLE
Remove special character from moeo_socialservicesitelocations

### DIFF
--- a/facdb/sql/moeo_socialservicesitelocations.sql
+++ b/facdb/sql/moeo_socialservicesitelocations.sql
@@ -21,7 +21,7 @@ SELECT
     (CASE
         WHEN program_name = 'NORC SITES' THEN 'NORC Services'
         WHEN program_name = 'TRANSPORTATION ONLY' THEN 'Transportation'
-        WHEN program_name = 'School’s Out New York City (SONYC)' THEN 'Schools Out New York City (SONYC)'
+        WHEN program_name = 'School’s Out New York City (SONYC)' THEN 'School''s Out New York City (SONYC)'
         ELSE initcap(program_name)
     END) as factype,
     (CASE
@@ -38,7 +38,7 @@ SELECT
             'Cornerstone',
             'Educational Support: High School Youth',
             'PEAK Centers',
-            'Schools Out New York City (SONYC)',
+            'School''s Out New York City (SONYC)',
             'Teen Rapp',
             'Youth Recreational Services/Youth Athletic Leagues')
             THEN 'After-School Programs'

--- a/facdb/sql/moeo_socialservicesitelocations.sql
+++ b/facdb/sql/moeo_socialservicesitelocations.sql
@@ -21,6 +21,7 @@ SELECT
     (CASE
         WHEN program_name = 'NORC SITES' THEN 'NORC Services'
         WHEN program_name = 'TRANSPORTATION ONLY' THEN 'Transportation'
+        WHEN program_name = 'School’s Out New York City (SONYC)' THEN 'Schools Out New York City (SONYC)'
         ELSE initcap(program_name)
     END) as factype,
     (CASE
@@ -37,7 +38,7 @@ SELECT
             'Cornerstone',
             'Educational Support: High School Youth',
             'PEAK Centers',
-            'School’s Out New York City (SONYC)',
+            'Schools Out New York City (SONYC)',
             'Teen Rapp',
             'Youth Recreational Services/Youth Athletic Leagues')
             THEN 'After-School Programs'


### PR DESCRIPTION
Lynn flagged that the "School's Out NYC (SONYC)" factype in the `moeo_socailservicesitelocations` was displaying a `?` instead of an `'`. I updated the code to remove apostrophe and subsequently should remove the issue with the `?` coming up in its place

This should resolve issue #558 