### PR TITLE
Update table name

### DIFF
--- a/facdb/metadata.yml
+++ b/facdb/metadata.yml
@@ -1,0 +1,1 @@
+datasets: []

--- a/facdb/sql/dsny_donatenycdirectory.sql
+++ b/facdb/sql/dsny_donatenycdirectory.sql
@@ -1,4 +1,4 @@
-DROP TABLE IF EXISTS _dsny_textiledrop;
+DROP TABLE IF EXISTS _dsny_donatenycdirectory;
 SELECT uid,
     source,
     CONCAT(site, ' Textile Drop-off Site') as facname,
@@ -22,7 +22,7 @@ SELECT uid,
     geo_1b,
     geo_bl,
     geo_bn
-INTO _dsny_textiledrop
-FROM dsny_textiledrop;
+INTO _dsny_donatenycdirectory
+FROM dsny_donatenycdirectory;
 
-CALL append_to_facdb_base('_dsny_textiledrop');
+CALL append_to_facdb_base('_dsny_donatenycdirectory');


### PR DESCRIPTION
The old `dsny_donatenycdirectory.sql` file worked on my local as the `dsny_textiledrop` table was still there from the old build. It failed on the github build as the postgres database was clean and didn't have outdated tables. This should be an easy merge and when it's in can re-build facDB