### PR TITLE
Change Program Name to original name in FacSubgrup lookup

### DIFF
--- a/facdb/sql/moeo_socialservicesitelocations.sql
+++ b/facdb/sql/moeo_socialservicesitelocations.sql
@@ -38,7 +38,7 @@ SELECT
             'Cornerstone',
             'Educational Support: High School Youth',
             'PEAK Centers',
-            'School''s Out New York City (SONYC)',
+            'School’s Out New York City (SONYC)',
             'Teen Rapp',
             'Youth Recreational Services/Youth Athletic Leagues')
             THEN 'After-School Programs'


### PR DESCRIPTION
The Program Name is not changed when looking up the facsubgrp.  By changing it the assignment of a facsubtype is failing.